### PR TITLE
processes :D

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -26,7 +26,7 @@ void proc_a_entry(void) {
   cprintf("Starting process A\n");
   while (1) {
     putchar('A');
-    switch_process(proc_a, proc_b);
+    yield();
     delay();
   }
 }
@@ -35,7 +35,7 @@ void proc_b_entry(void) {
   cprintf("Starting process B\n");
   while (1) {
     putchar('B');
-    switch_process(proc_b, proc_a);
+    yield();
     delay();
   }
 }
@@ -47,11 +47,12 @@ void kmain(void) {
   if (PRINT_SYS_INFO)
     read_fdt(dtb_address);
 
+  init_proc();
+
   proc_a = create_process(proc_a_entry);
   proc_b = create_process(proc_b_entry);
-  proc_a_entry();
 
-  /*verify_disk();*/
+  yield();
 
   print("Hello world!\r\n");
 

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -15,8 +15,6 @@
 struct proc *proc_a;
 struct proc *proc_b;
 
-int guh = 0;
-
 void proc_a_entry(void) {
   cprintf("Starting process A\n");
   for (int i = 0; i < 5; i++) {

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1,43 +1,38 @@
-#include "lib/exception.h"
-#include <stddef.h>
-
 #include "lib/device_tree.h"
 #include "lib/disk.h"
+#include "lib/exception.h"
 #include "lib/memory.h"
 #include "lib/paging.h"
+#include "lib/pci.h"
 #include "lib/print.h"
 #include "lib/process.h"
 #include "lib/string.h"
 #include "lib/system.h"
-#include "lib/pci.h"
 #include "lib/uart.h"
 
 #define PRINT_SYS_INFO 0
 
-void delay(void) {
-  for (int i = 0; i < 30000000; i++)
-    __asm__ __volatile__("nop");
-}
-
 struct proc *proc_a;
 struct proc *proc_b;
 
+int guh = 0;
+
 void proc_a_entry(void) {
   cprintf("Starting process A\n");
-  while (1) {
-    putchar('A');
+  for (int i = 0; i < 5; i++) {
+    cprintf("A running for the %d. time...\n", i + 1);
     yield();
-    delay();
   }
+  cprintf("Process A is done!\n");
 }
 
 void proc_b_entry(void) {
   cprintf("Starting process B\n");
-  while (1) {
-    putchar('B');
+  for (int i = 0; i < 8; i++) {
+    cprintf("B running for the %d. time...\n", i + 1);
     yield();
-    delay();
   }
+  cprintf("Process B is done!\n");
 }
 
 void kmain(void) {
@@ -47,14 +42,14 @@ void kmain(void) {
   if (PRINT_SYS_INFO)
     read_fdt(dtb_address);
 
+  // ! Must be called before using processes !
   init_proc();
 
   proc_a = create_process(proc_a_entry);
   proc_b = create_process(proc_b_entry);
 
   yield();
-
-  print("Hello world!\r\n");
+  print("\nAll processes finished execution!\n");
 
   WRITE_CSR(mtvec, (uint64_t)kernel_entry);
   __asm__ __volatile__("unimp");
@@ -81,10 +76,10 @@ void kmain(void) {
   cprintf("%d\n", 101);
 
   enumerate_pci();
-  
+
   PANIC("uh oh spaghettios %d", 5);
   print("we will never print this");
   print("\n");
-  print("death");
+  print("death\n");
   poweroff();
 }

--- a/src/lib/common.h
+++ b/src/lib/common.h
@@ -7,7 +7,7 @@ typedef int uint32_t;
 typedef long long uint64_t;
 typedef long double uint128_t;
 
-typedef uint32_t uintptr_t;
+typedef uint64_t uintptr_t;
 
 #define NULL 0
 

--- a/src/lib/memory.c
+++ b/src/lib/memory.c
@@ -1,5 +1,4 @@
 #include "memory.h"
-#include <stddef.h>
 
 void memset(const char *dst, char c, size_t n) {
   char *d = (char *)dst;

--- a/src/lib/memory.h
+++ b/src/lib/memory.h
@@ -1,4 +1,5 @@
 
+// @TODO: Remove stddef dependency
 #include <stddef.h>
 
 void memset(const char *p, char c, size_t n);

--- a/src/lib/print.c
+++ b/src/lib/print.c
@@ -1,10 +1,9 @@
-#include <stdarg.h>
-#include <stddef.h>
-
+#include "print.h"
 #include "assert.h"
 #include "common.h"
-#include "print.h"
 #include "uart.h"
+// @TODO: Don't depend on stdarg.h!
+#include <stdarg.h>
 
 #define DIGIT_COUNT 36
 

--- a/src/lib/process.c
+++ b/src/lib/process.c
@@ -1,0 +1,85 @@
+#include "process.h"
+#include "system.h"
+
+struct proc processes[MAX_PROCCESSES];
+
+#define SAVE(reg, var)                                                         \
+  do {                                                                         \
+    __asm__ volatile("mv %0, " reg : "=r"(var));                               \
+  } while (0)
+
+#define RESTORE(reg, var)                                                      \
+  do {                                                                         \
+    __asm__ volatile("mv " reg ", %0" : "=r"(var));                            \
+  } while (0)
+
+__attribute__((naked)) void switch_process(proc_t *current_process,
+                                           proc_t *next_process) {
+
+  // 1. Copy current registers into the struct pointed to by a1
+  // 2. Copy registers from the struct pointed to by a0 into current registers
+  // 3. return and pray
+  __asm__ __volatile__("sd ra,    8(a0)\n"
+                       "sd s0,   16(a0)\n"
+                       "sd s1,   24(a0)\n"
+                       "sd s2,   32(a0)\n"
+                       "sd s3,   40(a0)\n"
+                       "sd s4,   48(a0)\n"
+                       "sd s5,   56(a0)\n"
+                       "sd s6,   64(a0)\n"
+                       "sd s7,   72(a0)\n"
+                       "sd s8,   80(a0)\n"
+                       "sd s9,   88(a0)\n"
+                       "sd s10,  96(a0)\n"
+                       "sd s11, 104(a0)\n"
+
+                       "ld ra,    8(a1)\n"
+                       "ld s0,   16(a1)\n"
+                       "ld s1,   24(a1)\n"
+                       "ld s2,   32(a1)\n"
+                       "ld s3,   40(a1)\n"
+                       "ld s4,   48(a1)\n"
+                       "ld s5,   56(a1)\n"
+                       "ld s6,   64(a1)\n"
+                       "ld s7,   72(a1)\n"
+                       "ld s8,   80(a1)\n"
+                       "ld s9,   88(a1)\n"
+                       "ld s10,  96(a1)\n"
+                       "ld s11, 104(a1)\n"
+
+                       "ret");
+}
+
+struct proc *create_process(void *target_function) {
+  struct proc *process = NULL;
+
+  int i;
+  for (i = 0; i < MAX_PROCCESSES; i++) {
+    if (processes[i].state == PROCESS_EMPTY) {
+      process = &processes[i];
+      break;
+    }
+  }
+
+  if (!process)
+    PANIC("No empty processes");
+
+  process->state = PROCESS_RUNNABLE;
+  process->pid = i + 1;
+
+  process->reg.s0 = 1;
+  process->reg.s1 = 2;
+  process->reg.s2 = 3;
+  process->reg.s3 = 4;
+  process->reg.s4 = 5;
+  process->reg.s5 = 6;
+  process->reg.s6 = 7;
+  process->reg.s7 = 8;
+  process->reg.s8 = 9;
+  process->reg.s9 = 10;
+  process->reg.s10 = 11;
+  process->reg.s11 = 12;
+
+  process->reg.ra = (uint64_t)target_function;
+  return process;
+}

--- a/src/lib/process.c
+++ b/src/lib/process.c
@@ -4,16 +4,6 @@
 proc_t processes[MAX_PROCCESSES];
 proc_t *current_proc = NULL;
 
-#define SAVE(reg, var)                                                         \
-  do {                                                                         \
-    __asm__ volatile("mv %0, " reg : "=r"(var));                               \
-  } while (0)
-
-#define RESTORE(reg, var)                                                      \
-  do {                                                                         \
-    __asm__ volatile("mv " reg ", %0" : "=r"(var));                            \
-  } while (0)
-
 __attribute__((naked)) void switch_process(proc_t *current_process,
                                            proc_t *next_process) {
 

--- a/src/lib/process.h
+++ b/src/lib/process.h
@@ -7,6 +7,7 @@
 
 #define PROCESS_EMPTY 0
 #define PROCESS_RUNNABLE 1
+#define PROCESS_READY 2
 
 struct proc_registers {
   uint64_t ra;  //   8
@@ -31,7 +32,8 @@ struct proc {
   int state; // 4
 
   proc_registers_t reg; // 8
-  uint8_t stack[4096];  // 120
+  // NOTE: Pointers are 64-bit, but the stack is 8-bit aligned!
+  uint8_t stack[4096]; // 120
 };
 typedef struct proc proc_t;
 
@@ -39,5 +41,6 @@ void switch_process(proc_t *current_process, proc_t *next_process);
 proc_t *create_process(void *target_fuction);
 void init_proc(void);
 void yield(void);
+void exit_proc(void);
 
 #endif // !PROCESS_H

--- a/src/lib/process.h
+++ b/src/lib/process.h
@@ -22,6 +22,7 @@ struct proc_registers {
   uint64_t s9;  //  88
   uint64_t s10; //  96
   uint64_t s11; // 104
+  uint64_t sp;  // 112
 };
 typedef struct proc_registers proc_registers_t;
 
@@ -30,10 +31,13 @@ struct proc {
   int state; // 4
 
   proc_registers_t reg; // 8
+  uint8_t stack[4096];  // 120
 };
 typedef struct proc proc_t;
 
-void switch_process(struct proc *current_process, struct proc *next_process);
-struct proc *create_process(void *target_fuction);
+void switch_process(proc_t *current_process, proc_t *next_process);
+proc_t *create_process(void *target_fuction);
+void init_proc(void);
+void yield(void);
 
 #endif // !PROCESS_H

--- a/src/lib/process.h
+++ b/src/lib/process.h
@@ -1,0 +1,39 @@
+#ifndef PROCESS_H
+#define PROCESS_H
+
+#include "common.h"
+
+#define MAX_PROCCESSES 8
+
+#define PROCESS_EMPTY 0
+#define PROCESS_RUNNABLE 1
+
+struct proc_registers {
+  uint64_t ra;  //   8
+  uint64_t s0;  //  16
+  uint64_t s1;  //  24
+  uint64_t s2;  //  32
+  uint64_t s3;  //  40
+  uint64_t s4;  //  48
+  uint64_t s5;  //  56
+  uint64_t s6;  //  64
+  uint64_t s7;  //  72
+  uint64_t s8;  //  80
+  uint64_t s9;  //  88
+  uint64_t s10; //  96
+  uint64_t s11; // 104
+};
+typedef struct proc_registers proc_registers_t;
+
+struct proc {
+  int pid;   // 0
+  int state; // 4
+
+  proc_registers_t reg; // 8
+};
+typedef struct proc proc_t;
+
+void switch_process(struct proc *current_process, struct proc *next_process);
+struct proc *create_process(void *target_fuction);
+
+#endif // !PROCESS_H

--- a/src/lib/system.c
+++ b/src/lib/system.c
@@ -1,8 +1,6 @@
-#include <stddef.h>
-
+#include "system.h"
 #include "common.h"
 #include "print.h"
-#include "system.h"
 
 #define SYSCON_ADDR 0x100000
 


### PR DESCRIPTION
- **Add multi-processing :D**
- **Fix uintptr_t size**
- **Implement yield and add stacks to the processes**

We can now init processes by calling `create_process(func)`. A process must then
`yield()` when it is ready to pass on its execution context to the next process.
The kernel starts a special idle process before initiating any other processes
by calling `init_proc()`. It is impossible for a process to switch to the
kernel's idle process using `yield()`. If a process does not call `yield()`,
it's execution context will return to the previous process that `yield`ed to it.
If this bubbles up far enough, execution context will return to the kernel, and
it will power off.
