### PR TITLE
Heap fixes

### DIFF
--- a/src/kernel/drivers/device_tree.c
+++ b/src/kernel/drivers/device_tree.c
@@ -244,7 +244,11 @@ void print_node(fdt_node_t *node, u8 indent) {
   print("\n");
 }
 
-void free_node(fdt_node_t *node_ptr) {
+/**
+ * Frees a nodes properties and children from memory. Does not free the node
+ * itself.
+ */
+void free_node_metadata(fdt_node_t *node_ptr) {
   // Free properties list
   if (node_ptr->property_count > 0) {
     kfree(node_ptr->properties);
@@ -253,11 +257,19 @@ void free_node(fdt_node_t *node_ptr) {
   // Free each child
   if (node_ptr->child_count > 0) {
     for (size_t i = 0; i < node_ptr->child_count; i++) {
-      free_node(&node_ptr->children[i]);
+      free_node_metadata(&node_ptr->children[i]);
     }
     // Free child list
     kfree(node_ptr->children);
   }
+}
+
+/**
+ * Frees a node, its properties and its children from memory.
+ */
+void free_node(fdt_node_t *node_ptr) {
+  // Free props and children
+  free_node_metadata(node_ptr);
 
   // Free top node
   kfree(node_ptr);

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -12,9 +12,6 @@
 #include "memory/paging.h"
 #include "memory/virt_memory.h"
 
-struct proc *proc_a;
-struct proc *proc_b;
-struct proc *proc_c;
 extern char stack_top[];
 
 void kmain(void) {
@@ -36,18 +33,16 @@ void kmain(void) {
   // ===== Don't touch anything above this line unless u smort =====
 
   init_virtio_vga();
-  proc_c = create_process((void *)0x1000000, 0);
-
   // === FDT ===
-  // fdt_node_t *node = find_fdt("cpus");
-  // cprintf("Found node: %s\n", node->name);
-  // print_node(node, 2);
-  //
+  fdt_node_t *node = find_fdt("cpus");
+  cprintf("Found node: %s\n", node->name);
+  print_node(node, 2);
+
   // print("Before free:");
   //
   // print_heap_contents();
-  //
-  // free_node(node);
+
+  free_node(node);
   // print("After free:");
   //
   // print_heap_contents();

--- a/src/kernel/lib/common.h
+++ b/src/kernel/lib/common.h
@@ -35,6 +35,9 @@ typedef uintptr uptr;
 
 #define NULL 0
 
+#define TRUE 1
+#define FALSE 0
+
 // Functions
 
 u32 swap_endian_32(u32 val);

--- a/src/kernel/memory/kheap.c
+++ b/src/kernel/memory/kheap.c
@@ -1,4 +1,6 @@
+#include "kheap.h"
 #include "../drivers/system.h"
+#include "../lib/assert.h"
 #include "../lib/common.h"
 #include "../lib/print.h"
 #include "memory.h"
@@ -6,44 +8,43 @@
 
 #define DEBUG 0
 
-struct block {
-  size_t size;
-  struct block *next;
-  int free;
-} __attribute__((aligned(8)));
+block_t *blocks = NULL;
 
-struct block *blocks = NULL;
-
-#define BLOCK_SIZE sizeof(struct block)
+#define BLOCK_SIZE sizeof(block_t)
 
 #define BLOCK_TO_PTR(b) ((void *)((char *)(b) + BLOCK_SIZE))
 
-#define PTR_TO_BLOCK(p) ((struct block *)((char *)(p) - BLOCK_SIZE))
+#define PTR_TO_BLOCK(p) ((block_t *)((char *)(p) - BLOCK_SIZE))
 
 #define TOTAL_BLOCK_SIZE(s) ((s) + BLOCK_SIZE)
 
 int max_size = 0;
 
 void print_heap_contents() {
-  struct block *current = blocks;
+  block_t *current = blocks;
   cprintf("Heap blocks:\n");
   cprintf("  -------------------------\n");
   while (current != NULL) {
-    cprintf("  Block at %p:\n", (void *)current);
-    cprintf("  Size: %ld bytes\n", current->size - sizeof(struct block));
-    cprintf("  Status: %s\n", current->free ? "Free" : "Allocated");
-    cprintf("  Next Block: %p\n", (void *)current->next);
+    cprintf("  Address: 0x%p\n", (void *)current);
+    cprintf("  Size:    %ld bytes\n", current->size);
+    cprintf("  Alloced: %ld bytes\n", current->size - BLOCK_SIZE);
+    cprintf("  Status:  %s\n", current->free ? "Free" : "Allocated");
+    cprintf("  Next:    0x%p\n", (void *)current->next);
     cprintf("  -------------------------\n");
     current = current->next;
   }
 }
 int init_heap(int page_numbers) {
+  if (DEBUG) {
+    cprintf("BLOCK SIZE: %d\n", BLOCK_SIZE);
+  }
+
   void *pages = (void *)alloc_pages(page_numbers);
-  blocks = (struct block *)pages;
+  blocks = (block_t *)pages;
   max_size = page_numbers * PAGE_SIZE;
 
-  struct block init_block = {
-      max_size - sizeof(struct block),
+  block_t init_block = {
+      max_size - sizeof(block_t),
       NULL,
       1,
   };
@@ -58,24 +59,25 @@ void *kmalloc(int size) {
     cprintf("Trying to allocate %d bytes\n", size);
   }
 
-  struct block *current = blocks;
+  block_t *current = blocks;
 
   while (current) {
     // if the block is free and big enough
-    if (current->free && current->size - sizeof(struct block) >= size) {
+    if (current->free && current->size - sizeof(block_t) >= size) {
       // if we need to split the block
       // A split requires that the current block has enough space to support
       // 1. The new allocated size for left split
       // 2. The block header for left split
       // 3. At least 1 allocated byte for right split
       // 4. The block header for right split
-      if (current->size > size + 1 + sizeof(struct block) * 2) {
-        struct block *old = current;
-        struct block *left_split = old;
-        struct block *right_split = old + TOTAL_BLOCK_SIZE(size);
+      if (current->size > size + 1 + sizeof(block_t) * 2) {
+        block_t *old = current;
+        void *old_ptr = current;
+        block_t *left_split = (block_t *)old_ptr;
+        block_t *right_split = (block_t *)(old_ptr + TOTAL_BLOCK_SIZE(size));
 
         // Set new block sizes
-        uptr old_end = (uptr)old + old->size;
+        uptr old_end = (uptr)old_ptr + old->size;
         left_split->size = TOTAL_BLOCK_SIZE(size);
 
         uptr left_end = (uptr)left_split + left_split->size;
@@ -107,18 +109,35 @@ void *kmalloc(int size) {
 }
 
 int kfree(void *ptr) {
-  struct block *block = (struct block *)(ptr - sizeof(struct block));
-  block->free = 1;
-  // @TODO: Wanna implement this again eventually
-  // merge free blocks
-  // struct block *current = block->next;
-  // while (current) {
-  //   if (current && current && current->next) {
-  //     current->size += sizeof(struct block) + current->size;
-  //     current = current->next;
-  //   }
-  //   current = current->next;
-  // }
+  if (DEBUG) {
+    print("Before free:");
+    print_heap_contents();
+  }
+
+  block_t *block = (block_t *)(ptr - BLOCK_SIZE);
+  kassert(block->free == FALSE);
+  block->free = TRUE;
+
+  // Merge adjacent free blocks
+  block_t *current = block->next;
+
+  while (1) {
+    if (current && current->free) {
+      block->size += current->size;
+      block->next = current->next;
+
+      if (DEBUG) {
+        cprintf("Merged block at %p with next block at %p\n", (void *)block,
+                (void *)current);
+        print_heap_contents();
+      }
+
+      current = current->next;
+    } else {
+      break;
+    }
+  }
+
   return 1;
 }
 
@@ -126,21 +145,20 @@ void *krealloc(void *ptr, int size) {
   if (DEBUG)
     cprintf("Trying to realloc ptr %p to size %d\n", ptr, size);
 
-  struct block *block = (struct block *)(ptr - sizeof(struct block));
+  block_t *block = (block_t *)(ptr - sizeof(block_t));
 
-  if (size < block->size - sizeof(struct block)) {
-    int remaining_size = block->size - size - sizeof(struct block);
+  if (size < block->size - sizeof(block_t)) {
+    int remaining_size = block->size - size - sizeof(block_t);
     if (DEBUG)
       cprintf("REMAINING SIZE %d\n", remaining_size);
 
-    if (remaining_size > sizeof(struct block)) {
-      struct block *new_block =
-          (struct block *)((char *)block + sizeof(struct block) + size);
+    if (remaining_size > sizeof(block_t)) {
+      block_t *new_block = (block_t *)((char *)block + sizeof(block_t) + size);
       new_block->size = remaining_size;
       new_block->free = 1;
       new_block->next = block->next;
 
-      block->size = size + sizeof(struct block);
+      block->size = size + sizeof(block_t);
       block->next = new_block;
     }
 
@@ -148,8 +166,8 @@ void *krealloc(void *ptr, int size) {
   }
 
   int possible_size = block->size;
-  struct block *current = block->next;
-  struct block *prev = block;
+  block_t *current = block->next;
+  block_t *prev = block;
   // check if we can expand current block
   while (possible_size < size && current) {
     if (current->free) {
@@ -161,17 +179,15 @@ void *krealloc(void *ptr, int size) {
     break;
   }
   if (possible_size >= size) {
-    struct block *new_block =
-        (struct block *)((char *)block + sizeof(struct block) + size);
+    block_t *new_block = (block_t *)((char *)block + sizeof(block_t) + size);
     block->next = new_block;
 
     new_block->next = current;
     new_block->free = 1;
-    new_block->size =
-        prev->size - (block->size - (size + sizeof(struct block)));
-    block->size = size + sizeof(struct block);
+    new_block->size = prev->size - (block->size - (size + sizeof(block_t)));
+    block->size = size + sizeof(block_t);
     block->next = new_block;
-    return ((void *)block + sizeof(struct block));
+    return ((void *)block + sizeof(block_t));
     // expand current block
   } else {
     // alloc new block and free the old

--- a/src/kernel/memory/kheap.h
+++ b/src/kernel/memory/kheap.h
@@ -3,8 +3,9 @@
 struct block {
   size_t size;
   struct block *next;
-  int free;
-};
+  u8 free;
+} __attribute__((aligned(8)));
+typedef struct block block_t;
 
 int init_heap(int page_numbers);
 


### PR DESCRIPTION
Fixes
- When heap tries to allocate `n` bytes, it would push the next block `n * 24` bytes back due to wrong pointer types.
- `kfree` now properly merges the freed block with all free blocks that immediately follow it.
  - We may want to eventually merge backwards if memory fragmentation becomes an issue. Currently, if blocks are freed in order of lowest memory address to highest, no merging will take place, as each block has no referenced to the blocks that precede it, so walking backwards through the linked list is impossible.
- Issue with `free_node` that would cause it to try to free memory that
  1. had never been allocated to begin with
  2. had already been freed

That last one should probably have gone in the device tree PR, but I couldn't be bothered

depends on #35 and maybe #36 not sure