### PR TITLE
Add support for path-based device tree lookups

### DIFF
--- a/src/kernel/drivers/device_tree.h
+++ b/src/kernel/drivers/device_tree.h
@@ -11,6 +11,22 @@
 
 #define FDT_MAGIC 0xD00DFEED
 
+#define PROP_CMP_NIL (0b00000001) /* No value provided */
+#define PROP_CMP_STR (0b00000010) /* Value is a string */
+#define PROP_CMP_U64 (0b00000100) /* Value is a u64 */
+#define PROP_CMP_U32 (0b00001000) /* Value is a u32 */
+
+/* Key is optional, match if it doesn't exist */
+#define PROP_CMP_OPT (0b01000000)
+#define PROP_CMP_NEG (0b10000000) /* Negate the match on the value */
+
+#define PROP_CMP_MASK_INT (0b00001100) /* Mask for integer types */
+
+#define PROP_STATE_NOT_FOUND (0x01) /* No prop name was found */
+/* Prop name was found, but value did not match */
+#define PROP_STATE_BAD_MATCH (0x02)
+#define PROP_STATE_GOOD_MATCH (0x03) /* Prop name and value matched */
+
 struct fdt_header {
   u32 magic;
   u32 totalsize;

--- a/src/kernel/drivers/uart.c
+++ b/src/kernel/drivers/uart.c
@@ -10,7 +10,7 @@ volatile u8 *UART_LSR = NULL;
 
 void init_uart(void) {
   // Get serial node
-  char *serial = match_node("serial@");
+  char *serial = match_node("serial@[status?='okay']");
   UART_BASE = get_node_addr(serial);
   UART_DATA = (volatile u8 *)(UART_BASE + 0x00);
   UART_LSR = (volatile u8 *)(UART_BASE + 0x05);

--- a/src/kernel/lib/common.c
+++ b/src/kernel/lib/common.c
@@ -1,8 +1,19 @@
 #include "common.h"
 
 u32 swap_endian_32(u32 val) {
-  return ((val >> 24) & 0xff) | ((val >> 8) & 0xff00) |
-         ((val << 8) & 0xff0000) | ((val << 24) & 0xff000000);
+  return ((val >> 24) & 0x000000ffU) | ((val >> 8) & 0x0000ff00U) |
+         ((val << 8) & 0x00ff0000U) | ((val << 24) & 0xff000000U);
+}
+
+u64 swap_endian_64(u64 val) {
+  return ((val >> 56) & 0x00000000000000ffUL) |
+         ((val >> 40) & 0x000000000000ff00UL) |
+         ((val >> 24) & 0x0000000000ff0000UL) |
+         ((val >> 8) & 0x00000000ff000000UL) |
+         ((val << 8) & 0x000000ff00000000UL) |
+         ((val << 24) & 0x0000ff0000000000UL) |
+         ((val << 40) & 0x00ff000000000000UL) |
+         ((val << 56) & 0xff00000000000000UL);
 }
 
 s8 hex_char_to_int(char c) {

--- a/src/kernel/lib/common.h
+++ b/src/kernel/lib/common.h
@@ -54,6 +54,7 @@ typedef __builtin_va_list va_list;
 // === Functions ===
 
 u32 swap_endian_32(u32 val);
+u64 swap_endian_64(u64 val);
 s8 hex_char_to_int(char c);
 
 #endif // !COMMON_H


### PR DESCRIPTION
docs are
```
node_name[search_prop_name=search_prop_value]*prop_name
```
where
- `node_name`: optional node name to look for. It will match the start of the string.
- `[...]`: optional property-based search. If specified, will only find a node that has the property/value defined inside the brackets.
  - `search_prop_name`: name of the property used for the lookup
  - `=`: equality divisor. This divisor can be prepended by the following:
    - `!`: negative lookup, will match nodes that have the prop `search_prop_name` whose value is NOT `search_prop_value`.
    - `?`: optional lookup, will match nodes that do not have have a property named `search_prop_name`. If a node does have `search_prop_name`, will only match if `search_prop_value` matches, unless `!` is also specified.
  - `search_prop_value`: value of the property used for the lookup. This can have the following two formats:
    - `'string'`: string value, needs the single quotes.
    - `<hex>`: hex value, needs to angle brackets. Do not include `0x`. Note that this is with swapped endianness.
- `prop_name`: optional prop name to retrieve once a match has been made. If this is not defined, the search will return the full node name. If it is defined, but is not found on the matched node, NULL is returned. If it is defined, and is found, its value will be returned as a `void *`. Note that it is not endianness is not swapped for the returned value.